### PR TITLE
Potential fix for code scanning alert no. 2: Stored cross-site scripting

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,9 +49,9 @@ function Home({ userIds }: InferGetStaticPropsType<typeof getStaticProps>) {
 export const getStaticProps: GetStaticProps = async () => {
   const dataDirectory = path.join(process.cwd(), "data");
   const filenames = fs.readdirSync(dataDirectory);
-  const userIds = filenames.map((filename) => {
-    return path.basename(filename, ".json");
-  });
+  const userIds = filenames
+    .map((filename) => path.basename(filename, ".json"))
+    .filter((userId) => /^[a-zA-Z0-9_-]+$/.test(userId));
   return {
     props: { userIds },
   };


### PR DESCRIPTION
Potential fix for [https://github.com/iwamot/didit/security/code-scanning/2](https://github.com/iwamot/didit/security/code-scanning/2)

To prevent any risk of stored cross-site scripting (or related attacks like open redirect/path traversal), the best practice is to sanitize or validate user-derived filenames before usage. Only allow "userIds" that match an expected safe pattern: for example, alphanumeric characters, hyphens, or underscores. This can be implemented by filtering or mapping filenames with a regular expression, rather than directly using the output of `fs.readdirSync` and `path.basename`. The changes should occur where the `userIds` array is constructed (inside `getStaticProps`), just before returning the data to the React component. No changes to import statements are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
